### PR TITLE
Detect zero'd section-related fields in the ELF header as anomalous

### DIFF
--- a/analysis/analysis/static.py
+++ b/analysis/analysis/static.py
@@ -231,11 +231,10 @@ def detect_anti_analysis_techniques(sample, sample_path):
         aaa.elflepton = True
         aaa.status = TaskStatus.COMPLETE
         aaa.save()
-
-    aa.packers = packer
     for tool_name in msg:
         setattr(aa, tool_name, msg[tool_name])
 
+    aa.packers = packer
     aa.status = TaskStatus.COMPLETE
     aa.save()
     return aa, aaa

--- a/analysis/analysis/utils/static/parse_elf.py
+++ b/analysis/analysis/utils/static/parse_elf.py
@@ -336,7 +336,7 @@ def get_basic_info(sample_path):
     LOG.debug(f"Getting basic info from {sample_path}")
     # If there is any anti-analysis technique used, the sample path is updated to
     # the fixed sample, and not the submitted sample.
-    sample_path, msg = static_anti_analysis.check_elf_header_corruption(sample_path)
+    sample_path, msg = static_anti_analysis.check_elf_header_anomalies(sample_path)
 
     if sample_path is None:
         LOG.error(f"ELF binary not in a state to be parsed.")

--- a/web/templates/web/report_file.html
+++ b/web/templates/web/report_file.html
@@ -195,9 +195,9 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
                         <div class="card-body overflow-auto text-center">
                             <ul>
                                 <li>
-                                    <a href="https://github.com/nikhilh-20/lepton">ELFLepton</a> found corruptions in
+                                    <a href="https://github.com/nikhilh-20/lepton">ELFLepton</a> found anomalies in
                                     the ELF header and tried to fix them before performing static analysis.
-                                    See Anti-Analysis section for more details on the ELF header corruption.
+                                    See Anti-Analysis section for more details on the ELF header anomalies.
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
If section-related fields in the ELF header (`e_shnum`, `e_shoff`, `e_shstrndx`) are zero'd out, `readelf` doesn't throw any error when `readelf -h <sample_path>` is executed. However, this is an anomaly and can be detected by also executing `readelf -S <sample_path>`